### PR TITLE
Update ngParallax.js

### DIFF
--- a/src/ngParallax.js
+++ b/src/ngParallax.js
@@ -31,13 +31,12 @@ angular.module('ngParallax').directive('ngParallax', [
           }
 
           var bgObj = elem[0];
-              bgObj.style.backgroundRepeat = "repeat";
-              bgObj.style.backgroundAttachment = "fixed";
               bgObj.style.height = "100%";
               bgObj.style.margin = "0 auto"
               bgObj.style.position = "relative"
               bgObj.style.background = "url(" + scope.pattern + ")"
               bgObj.style.backgroundAttachment = 'fixed';
+              bgObj.style.backgroundRepeat = "repeat";
           var isMobile = window.mobileAndTabletcheck();
 
 


### PR DESCRIPTION
Reorder the background styles, and remove duplicate backgroundAttachment line. The style.background attribute should be set before the sub attrributes such as backgroundAttachment and backgroundRepeat, because it overrides them. Either that or alternatively use style.backgroundImage to set the image specifically.